### PR TITLE
Add analytics page with spending insights and charts

### DIFF
--- a/web/app/visualizations/page.tsx
+++ b/web/app/visualizations/page.tsx
@@ -1,31 +1,798 @@
 'use client';
 
-import React from 'react';
-import { Box, Card, CardContent, Typography } from '@mui/material';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  Typography,
+} from '@mui/material';
+import {
+  TrendingDown as TrendingDownIcon,
+  TrendingUp as TrendingUpIcon,
+  Lightbulb as LightbulbIcon,
+  Category as CategoryIcon,
+  Warning as WarningIcon,
+  CheckCircle as CheckCircleIcon,
+  UploadFile as UploadFileIcon,
+} from '@mui/icons-material';
+import { useTheme, alpha } from '@mui/material/styles';
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as ReTooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import { useRouter } from 'next/navigation';
+import { createBrowserSupabaseClient } from '../../lib/supabase';
+import { formatUnknownError } from '../../lib/errors';
 
-export default function VisualizationsPage() {
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Period = '1m' | '3m' | '6m' | '1y' | 'all';
+
+type AnalyticsTransaction = {
+  id: string;
+  date: string;
+  description: string;
+  amount: number;
+  account_name: string;
+  category_name: string | null;
+};
+
+type Insight = {
+  severity: 'success' | 'warning' | 'error' | 'info';
+  message: string;
+};
+
+type CategoryRow = { name: string; amount: number; pct: number };
+type MonthRow = { month: string; Income: number; Expenses: number };
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PERIOD_OPTIONS: { value: Period; label: string }[] = [
+  { value: '1m', label: '1M' },
+  { value: '3m', label: '3M' },
+  { value: '6m', label: '6M' },
+  { value: '1y', label: '1Y' },
+  { value: 'all', label: 'All' },
+];
+
+const CATEGORY_COLORS = [
+  '#6366f1',
+  '#f59e0b',
+  '#10b981',
+  '#ec4899',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ef4444',
+  '#14b8a6',
+  '#f97316',
+  '#84cc16',
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fmt(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+function fmtAxis(value: number): string {
+  if (value >= 1000) return `$${(value / 1000).toFixed(0)}k`;
+  return `$${value}`;
+}
+
+function getPeriodStart(period: Period): string | null {
+  if (period === 'all') return null;
+  const d = new Date();
+  if (period === '1m') d.setMonth(d.getMonth() - 1);
+  else if (period === '3m') d.setMonth(d.getMonth() - 3);
+  else if (period === '6m') d.setMonth(d.getMonth() - 6);
+  else d.setFullYear(d.getFullYear() - 1);
+  return d.toISOString().split('T')[0];
+}
+
+function buildMonthlyData(txs: AnalyticsTransaction[]): MonthRow[] {
+  const map = new Map<string, { income: number; expenses: number }>();
+  for (const t of txs) {
+    const key = t.date.slice(0, 7);
+    const entry = map.get(key) ?? { income: 0, expenses: 0 };
+    if (t.amount < 0) entry.income += Math.abs(t.amount);
+    else entry.expenses += t.amount;
+    map.set(key, entry);
+  }
+  return Array.from(map.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, v]) => ({
+      month: new Date(key + '-01').toLocaleDateString('en-US', {
+        month: 'short',
+        year: '2-digit',
+      }),
+      Income: parseFloat(v.income.toFixed(2)),
+      Expenses: parseFloat(v.expenses.toFixed(2)),
+    }));
+}
+
+function buildCategoryData(txs: AnalyticsTransaction[]): CategoryRow[] {
+  const map = new Map<string, number>();
+  const expenses = txs.filter((t) => t.amount > 0);
+  for (const t of expenses) {
+    const name = t.category_name ?? 'Uncategorized';
+    map.set(name, (map.get(name) ?? 0) + t.amount);
+  }
+  const total = expenses.reduce((s, t) => s + t.amount, 0);
+  const sorted = Array.from(map.entries())
+    .sort(([, a], [, b]) => b - a)
+    .map(([name, amount]) => ({
+      name,
+      amount: parseFloat(amount.toFixed(2)),
+      pct: total > 0 ? (amount / total) * 100 : 0,
+    }));
+
+  // Collapse tail into "Other" when there are many categories
+  if (sorted.length > 8) {
+    const top = sorted.slice(0, 7);
+    const other = sorted.slice(7).reduce((s, c) => s + c.amount, 0);
+    return [
+      ...top,
+      {
+        name: 'Other',
+        amount: parseFloat(other.toFixed(2)),
+        pct: total > 0 ? (other / total) * 100 : 0,
+      },
+    ];
+  }
+  return sorted;
+}
+
+function buildInsights(
+  txs: AnalyticsTransaction[],
+  catData: CategoryRow[],
+  totalIncome: number,
+  totalExpenses: number,
+  uncategorized: number,
+): Insight[] {
+  const insights: Insight[] = [];
+
+  // Positive cash flow / savings rate
+  if (totalIncome > 0 && totalIncome >= totalExpenses) {
+    const saved = totalIncome - totalExpenses;
+    const rate = (saved / totalIncome) * 100;
+    insights.push({
+      severity: 'success',
+      message: `Savings rate of ${Math.round(rate)}% — you kept $${fmt(saved)} this period. Keep it up.`,
+    });
+  }
+
+  // Overspending
+  if (totalIncome > 0 && totalExpenses > totalIncome) {
+    insights.push({
+      severity: 'error',
+      message: `You overspent by $${fmt(totalExpenses - totalIncome)} this period. Review your top spending categories below.`,
+    });
+  }
+
+  // Dominant single category (excluding Uncategorized)
+  const topCat = catData.find((c) => c.name !== 'Uncategorized');
+  if (topCat && topCat.pct > 35) {
+    const saving = topCat.amount * 0.1;
+    insights.push({
+      severity: 'info',
+      message: `${topCat.name} is ${Math.round(topCat.pct)}% of your spending ($${fmt(topCat.amount)}). A 10% reduction there would save you $${fmt(saving)}/period.`,
+    });
+  }
+
+  // Uncategorized blind spots
+  const expenseCount = txs.filter((t) => t.amount > 0).length;
+  const pctUncategorized = expenseCount > 0 ? (uncategorized / expenseCount) * 100 : 0;
+  if (pctUncategorized > 15) {
+    insights.push({
+      severity: 'warning',
+      message: `${uncategorized} expense transactions (${Math.round(pctUncategorized)}%) are uncategorized. Categorize them to see where your money really goes.`,
+    });
+  }
+
+  return insights;
+}
+
+// ─── Chart sub-components ─────────────────────────────────────────────────────
+
+function ChartTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
   return (
-    <Box>
-      <Box mb={4}>
-        <Typography variant="h4" gutterBottom>
-          Analytics
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        border: '1px solid',
+        borderColor: 'divider',
+        borderRadius: 2,
+        p: 1.5,
+        boxShadow: 4,
+      }}
+    >
+      {label && (
+        <Typography variant="caption" color="text.secondary" display="block" mb={0.5}>
+          {label}
         </Typography>
-        <Typography variant="body1" color="text.secondary">
-          Visualizations are coming back next—this page is scaffolded to match the legacy nav/layout.
-        </Typography>
-      </Box>
-
-      <Card>
-        <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Coming soon
+      )}
+      {payload.map((entry: any) => (
+        <Box key={entry.name} display="flex" alignItems="center" gap={1}>
+          <Box
+            sx={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              bgcolor: entry.color ?? entry.fill,
+            }}
+          />
+          <Typography variant="body2">
+            {entry.name}: ${fmt(Math.abs(entry.value))}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            We’ll reintroduce charts once we finalize the Supabase-backed rollups and the data model for budgets/trends.
-          </Typography>
-        </CardContent>
-      </Card>
+        </Box>
+      ))}
     </Box>
   );
 }
 
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+export default function AnalyticsPage() {
+  const theme = useTheme();
+  const router = useRouter();
+  const supabase = useMemo(() => createBrowserSupabaseClient(), []);
+
+  const [period, setPeriod] = useState<Period>('3m');
+  const [transactions, setTransactions] = useState<AnalyticsTransaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const startDate = getPeriodStart(period);
+        const baseQuery = supabase
+          .from('transactions')
+          .select(
+            'id,date,description,amount,accounts(name),categories:categories!transactions_category_id_fkey(name)',
+          )
+          .order('date', { ascending: false })
+          .limit(5000);
+        const { data, error } = await (startDate ? baseQuery.gte('date', startDate) : baseQuery);
+        if (error) throw error;
+        if (!cancelled) {
+          setTransactions(
+            (data ?? []).map((r: any) => ({
+              id: String(r.id),
+              date: String(r.date),
+              description: String(r.description ?? ''),
+              amount:
+                typeof r.amount === 'number' ? r.amount : parseFloat(String(r.amount)),
+              account_name: String(r.accounts?.name ?? 'Unknown'),
+              category_name: (r.categories as any)?.name ?? null,
+            })),
+          );
+        }
+      } catch (e) {
+        if (!cancelled) setLoadError(formatUnknownError(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [period, supabase]);
+
+  // ── Aggregations ────────────────────────────────────────────────────────────
+
+  const stats = useMemo(() => {
+    const totalExpenses = transactions
+      .filter((t) => t.amount > 0)
+      .reduce((s, t) => s + t.amount, 0);
+    const totalIncome = transactions
+      .filter((t) => t.amount < 0)
+      .reduce((s, t) => s + Math.abs(t.amount), 0);
+    const uncategorized = transactions.filter(
+      (t) => t.amount > 0 && !t.category_name,
+    ).length;
+    const months = new Set(transactions.map((t) => t.date.slice(0, 7)));
+    return {
+      totalExpenses,
+      totalIncome,
+      net: totalIncome - totalExpenses,
+      avgMonthlyExpense: totalExpenses / Math.max(months.size, 1),
+      uncategorized,
+    };
+  }, [transactions]);
+
+  const monthlyData = useMemo(() => buildMonthlyData(transactions), [transactions]);
+  const categoryData = useMemo(() => buildCategoryData(transactions), [transactions]);
+  const topExpenses = useMemo(
+    () =>
+      transactions
+        .filter((t) => t.amount > 0)
+        .sort((a, b) => b.amount - a.amount)
+        .slice(0, 6),
+    [transactions],
+  );
+  const insights = useMemo(
+    () =>
+      buildInsights(
+        transactions,
+        categoryData,
+        stats.totalIncome,
+        stats.totalExpenses,
+        stats.uncategorized,
+      ),
+    [transactions, categoryData, stats],
+  );
+
+  const incomeColor = theme.palette.success.main;
+  const expenseColor = theme.palette.error.main;
+
+  // ── Render guards ───────────────────────────────────────────────────────────
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="60vh">
+        <Typography color="text.secondary">Loading analytics…</Typography>
+      </Box>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <Box>
+        <Typography variant="h4" gutterBottom>
+          Analytics
+        </Typography>
+        <Alert severity="error">Failed to load data: {loadError}</Alert>
+      </Box>
+    );
+  }
+
+  if (transactions.length === 0) {
+    return (
+      <Box>
+        <Typography variant="h4" gutterBottom>
+          Analytics
+        </Typography>
+        <Card
+          sx={{
+            minHeight: '60vh',
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            cursor: 'pointer',
+            transition: 'transform 0.2s, box-shadow 0.2s',
+            '&:hover': { transform: 'translateY(-3px)', boxShadow: theme.shadows[3] },
+          }}
+          onClick={() => router.push('/upload')}
+        >
+          <CardContent sx={{ textAlign: 'center' }}>
+            <UploadFileIcon sx={{ fontSize: 80, color: 'primary.main', mb: 2 }} />
+            <Typography variant="h5" gutterBottom>
+              No transactions for this period
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ maxWidth: 420, mx: 'auto' }}>
+              Upload bank statements to start seeing spending insights and trends.
+            </Typography>
+          </CardContent>
+        </Card>
+      </Box>
+    );
+  }
+
+  // ── Main render ─────────────────────────────────────────────────────────────
+
+  return (
+    <Box>
+      {/* ── Header ── */}
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={3}
+        flexWrap="wrap"
+        gap={2}
+      >
+        <Typography variant="h4">Analytics</Typography>
+        <Stack direction="row" spacing={0.5}>
+          {PERIOD_OPTIONS.map((opt) => (
+            <Chip
+              key={opt.value}
+              label={opt.label}
+              onClick={() => setPeriod(opt.value)}
+              color={period === opt.value ? 'primary' : 'default'}
+              variant={period === opt.value ? 'filled' : 'outlined'}
+              sx={{ fontWeight: period === opt.value ? 600 : 400 }}
+            />
+          ))}
+        </Stack>
+      </Box>
+
+      {/* ── KPI cards ── */}
+      <Grid container spacing={2} mb={3}>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent sx={{ textAlign: 'center', py: 2 }}>
+              <Box display="flex" alignItems="center" justifyContent="center" gap={1}>
+                <TrendingDownIcon color="success" />
+                <Typography variant="h6" color="success.main">
+                  ${fmt(stats.totalIncome)}
+                </Typography>
+              </Box>
+              <Typography variant="body2" color="text.secondary">
+                Total Income
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent sx={{ textAlign: 'center', py: 2 }}>
+              <Box display="flex" alignItems="center" justifyContent="center" gap={1}>
+                <TrendingUpIcon color="error" />
+                <Typography variant="h6" color="error.main">
+                  ${fmt(stats.totalExpenses)}
+                </Typography>
+              </Box>
+              <Typography variant="body2" color="text.secondary">
+                Total Expenses
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent sx={{ textAlign: 'center', py: 2 }}>
+              <Typography
+                variant="h6"
+                color={stats.net >= 0 ? 'success.main' : 'error.main'}
+              >
+                {stats.net >= 0 ? '+' : ''}${fmt(stats.net)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Net Cash Flow
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} sm={6} md={3}>
+          <Card>
+            <CardContent sx={{ textAlign: 'center', py: 2 }}>
+              <Typography variant="h6" color="primary">
+                ${fmt(stats.avgMonthlyExpense)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Avg Monthly Spend
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* ── Insights ── */}
+      {insights.length > 0 && (
+        <Box mb={3}>
+          <Box display="flex" alignItems="center" gap={1} mb={1.5}>
+            <LightbulbIcon color="primary" fontSize="small" />
+            <Typography variant="subtitle1" fontWeight={600}>
+              Insights
+            </Typography>
+          </Box>
+          <Stack spacing={1}>
+            {insights.map((insight, i) => (
+              <Alert
+                key={i}
+                severity={insight.severity}
+                icon={
+                  insight.severity === 'success' ? (
+                    <CheckCircleIcon />
+                  ) : insight.severity === 'warning' ? (
+                    <WarningIcon />
+                  ) : undefined
+                }
+              >
+                {insight.message}
+              </Alert>
+            ))}
+          </Stack>
+        </Box>
+      )}
+
+      {/* ── Charts row 1: monthly bar + category donut ── */}
+      <Grid container spacing={2} mb={2}>
+        <Grid item xs={12} md={7}>
+          <Card>
+            <CardContent>
+              <Typography variant="subtitle1" fontWeight={600} mb={2}>
+                Monthly Income vs Expenses
+              </Typography>
+              <ResponsiveContainer width="100%" height={270}>
+                <BarChart data={monthlyData} barGap={4} barCategoryGap="28%">
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke={alpha(theme.palette.divider, 0.7)}
+                  />
+                  <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+                  <YAxis tickFormatter={fmtAxis} tick={{ fontSize: 12 }} />
+                  <ReTooltip content={<ChartTooltip />} />
+                  <Legend />
+                  <Bar dataKey="Income" fill={incomeColor} radius={[4, 4, 0, 0]} />
+                  <Bar dataKey="Expenses" fill={expenseColor} radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={5}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="subtitle1" fontWeight={600} mb={2}>
+                Spending by Category
+              </Typography>
+              {categoryData.length === 0 ? (
+                <Box
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  height={270}
+                >
+                  <Typography variant="body2" color="text.secondary">
+                    No expense data
+                  </Typography>
+                </Box>
+              ) : (
+                <ResponsiveContainer width="100%" height={270}>
+                  <PieChart>
+                    <Pie
+                      data={categoryData}
+                      dataKey="amount"
+                      nameKey="name"
+                      cx="50%"
+                      cy="50%"
+                      innerRadius={68}
+                      outerRadius={108}
+                      paddingAngle={2}
+                    >
+                      {categoryData.map((_, i) => (
+                        <Cell
+                          key={i}
+                          fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                        />
+                      ))}
+                    </Pie>
+                    <ReTooltip content={<ChartTooltip />} />
+                    <Legend
+                      formatter={(value, entry: any) =>
+                        `${value} (${Math.round(entry.payload?.pct ?? 0)}%)`
+                      }
+                      iconSize={10}
+                      wrapperStyle={{ fontSize: 12 }}
+                    />
+                  </PieChart>
+                </ResponsiveContainer>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* ── Spending trend area chart ── */}
+      <Card sx={{ mb: 2 }}>
+        <CardContent>
+          <Typography variant="subtitle1" fontWeight={600} mb={2}>
+            Monthly Spending Trend
+          </Typography>
+          <ResponsiveContainer width="100%" height={200}>
+            <AreaChart data={monthlyData}>
+              <defs>
+                <linearGradient id="expGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={expenseColor} stopOpacity={0.28} />
+                  <stop offset="95%" stopColor={expenseColor} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={alpha(theme.palette.divider, 0.7)}
+              />
+              <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+              <YAxis tickFormatter={fmtAxis} tick={{ fontSize: 12 }} />
+              <ReTooltip content={<ChartTooltip />} />
+              <Area
+                type="monotone"
+                dataKey="Expenses"
+                stroke={expenseColor}
+                strokeWidth={2}
+                fill="url(#expGradient)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* ── Bottom row: top categories bar + largest expenses ── */}
+      <Grid container spacing={2} mb={2}>
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="subtitle1" fontWeight={600} mb={2}>
+                Top Spending Categories
+              </Typography>
+              {categoryData.length === 0 ? (
+                <Typography variant="body2" color="text.secondary">
+                  No data
+                </Typography>
+              ) : (
+                <ResponsiveContainer width="100%" height={230}>
+                  <BarChart
+                    layout="vertical"
+                    data={categoryData.slice(0, 6)}
+                    margin={{ left: 8, right: 24 }}
+                  >
+                    <CartesianGrid
+                      strokeDasharray="3 3"
+                      horizontal={false}
+                      stroke={alpha(theme.palette.divider, 0.7)}
+                    />
+                    <XAxis type="number" tickFormatter={fmtAxis} tick={{ fontSize: 12 }} />
+                    <YAxis
+                      type="category"
+                      dataKey="name"
+                      width={96}
+                      tick={{ fontSize: 12 }}
+                    />
+                    <ReTooltip content={<ChartTooltip />} />
+                    <Bar dataKey="amount" name="Spent" radius={[0, 4, 4, 0]}>
+                      {categoryData.slice(0, 6).map((_, i) => (
+                        <Cell
+                          key={i}
+                          fill={CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="subtitle1" fontWeight={600} mb={2}>
+                Largest Expenses
+              </Typography>
+              <Stack spacing={1}>
+                {topExpenses.map((t) => (
+                  <Box
+                    key={t.id}
+                    display="flex"
+                    justifyContent="space-between"
+                    alignItems="center"
+                    sx={{
+                      px: 1.5,
+                      py: 1,
+                      borderRadius: 2,
+                      bgcolor: alpha(theme.palette.action.hover, 0.5),
+                    }}
+                  >
+                    <Box minWidth={0} mr={1}>
+                      <Typography variant="body2" fontWeight={500} noWrap>
+                        {t.description}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {new Date(t.date).toLocaleDateString()} ·{' '}
+                        {t.category_name ?? 'Uncategorized'}
+                      </Typography>
+                    </Box>
+                    <Typography
+                      variant="body2"
+                      fontWeight={700}
+                      color="error.main"
+                      sx={{ whiteSpace: 'nowrap' }}
+                    >
+                      ${fmt(t.amount)}
+                    </Typography>
+                  </Box>
+                ))}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {/* ── Category breakdown table ── */}
+      {categoryData.length > 0 && (
+        <Card>
+          <CardContent>
+            <Typography variant="subtitle1" fontWeight={600} mb={2}>
+              Category Breakdown
+            </Typography>
+            <Grid container spacing={2}>
+              {categoryData.map((cat, i) => (
+                <Grid item xs={12} sm={6} md={4} key={cat.name}>
+                  <Box display="flex" alignItems="flex-start" gap={1.5} py={0.5}>
+                    <Box
+                      sx={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        bgcolor: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                        flexShrink: 0,
+                        mt: 0.5,
+                      }}
+                    />
+                    <Box flex={1} minWidth={0}>
+                      <Box
+                        display="flex"
+                        justifyContent="space-between"
+                        alignItems="center"
+                      >
+                        <Typography variant="body2" noWrap>
+                          {cat.name}
+                        </Typography>
+                        <Typography variant="body2" fontWeight={600} ml={1}>
+                          ${fmt(cat.amount)}
+                        </Typography>
+                      </Box>
+                      <Box
+                        sx={{
+                          height: 4,
+                          borderRadius: 2,
+                          bgcolor: alpha(
+                            CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                            0.18,
+                          ),
+                          mt: 0.5,
+                          position: 'relative',
+                          overflow: 'hidden',
+                        }}
+                      >
+                        <Box
+                          sx={{
+                            position: 'absolute',
+                            inset: 0,
+                            width: `${cat.pct}%`,
+                            bgcolor: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                            borderRadius: 2,
+                          }}
+                        />
+                      </Box>
+                      <Typography variant="caption" color="text.secondary">
+                        {Math.round(cat.pct)}% of spending
+                      </Typography>
+                    </Box>
+                  </Box>
+                </Grid>
+              ))}
+            </Grid>
+          </CardContent>
+        </Card>
+      )}
+    </Box>
+  );
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-plaid-link": "^4.1.1",
+        "recharts": "^3.7.0",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -1256,6 +1257,54 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.97.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.97.0.tgz",
@@ -1345,6 +1394,69 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -1399,6 +1511,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1833,6 +1951,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
@@ -1855,6 +2094,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2001,6 +2246,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.0.tgz",
+      "integrity": "sha512-RArCX+Zea16+R1jg4mH223Z8p/ivbJjIkU3oC6ld2bdUfmDxiCkFYSi9zLOR2anucWJUeH4Djnzgd0im0nD3dw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2012,6 +2267,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/exceljs": {
       "version": "4.4.0",
@@ -2314,6 +2575,16 @@
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2346,6 +2617,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -2967,6 +3247,29 @@
         "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -3026,6 +3329,57 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
+      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -3267,6 +3621,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -3359,6 +3719,15 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3372,6 +3741,28 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/wmf": {

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-plaid-link": "^4.1.1",
+    "recharts": "^3.7.0",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Replaces the \"Coming Soon\" scaffold at `/visualizations` with a fully functional analytics page
- Installs `recharts` for charting
- Adds `CLAUDE.md` with project architecture and development guide

## Analytics page features
- **Period selector** — 1M / 3M / 6M / 1Y / All time
- **KPI cards** — Total Income, Total Expenses, Net Cash Flow, Avg Monthly Spend
- **Auto-generated insights** — savings rate, overspending alerts, dominant category tips, uncategorized blind-spot warnings
- **Monthly Income vs Expenses** — grouped bar chart
- **Spending by Category** — donut chart with % breakdown
- **Monthly Spending Trend** — area chart
- **Top Spending Categories** — horizontal bar chart
- **Largest Expenses** — top 6 transactions list
- **Category Breakdown** — mini progress bars showing each category's share of total spend

## Test plan
- [ ] Visit `/visualizations` while authenticated with transaction data
- [ ] Toggle period chips (1M, 3M, 6M, 1Y, All) and confirm charts update
- [ ] Verify insights section appears and reflects actual data
- [ ] Confirm empty state shows upload prompt when no transactions exist for the period
- [ ] Check light and dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)